### PR TITLE
Update TileDB benchmarks

### DIFF
--- a/ann_benchmarks/algorithms/tiledb/Dockerfile
+++ b/ann_benchmarks/algorithms/tiledb/Dockerfile
@@ -1,8 +1,35 @@
-FROM tiledb_vs
+# # Mamba approach
+# FROM continuumio/miniconda3:4.10.3
 
-RUN mamba install -y ansicolors docker-py h5py matplotlib numpy pyyaml psutil scipy scikit-learn jinja2 pandas
+# RUN conda install mamba -n base -c conda-forge
 
-WORKDIR /home/app
-COPY requirements.txt run_algorithm.py ./
-RUN pip3 install -r requirements.txt
-ENTRYPOINT ["python", "-u", "run_algorithm.py"]
+# RUN mamba install -y -c tiledb tiledb tiledb-vector-search
+
+# WORKDIR /home/app
+# COPY requirements.txt run_algorithm.py ./
+# RUN pip3 install -r requirements.txt
+# ENTRYPOINT ["python", "-u", "run_algorithm.py"]
+
+# # Conda approach
+# FROM ann-benchmarks
+
+# RUN apt update && apt install -y wget
+# RUN wget https://repo.anaconda.com/archive/Anaconda3-2020.11-Linux-x86_64.sh
+# RUN bash Anaconda3-2020.11-Linux-x86_64.sh -b
+
+# ENV PATH /root/anaconda3/bin:$PATH
+
+# RUN conda install -y -c tiledb tiledb
+# RUN conda install -y -c conda-forge tiledb-vector-search
+
+# WORKDIR /home/app
+# COPY requirements.txt run_algorithm.py ./
+# RUN pip3 install -r requirements.txt
+# ENTRYPOINT ["python", "-u", "run_algorithm.py"]
+
+# Pip approach
+FROM ann-benchmarks
+
+RUN pip install tiledb
+RUN pip install tiledb-vector-search
+RUN python3 -c 'import tiledb.vector_search'

--- a/ann_benchmarks/algorithms/tiledb/Dockerfile
+++ b/ann_benchmarks/algorithms/tiledb/Dockerfile
@@ -1,35 +1,4 @@
-# # Mamba approach
-# FROM continuumio/miniconda3:4.10.3
-
-# RUN conda install mamba -n base -c conda-forge
-
-# RUN mamba install -y -c tiledb tiledb tiledb-vector-search
-
-# WORKDIR /home/app
-# COPY requirements.txt run_algorithm.py ./
-# RUN pip3 install -r requirements.txt
-# ENTRYPOINT ["python", "-u", "run_algorithm.py"]
-
-# # Conda approach
-# FROM ann-benchmarks
-
-# RUN apt update && apt install -y wget
-# RUN wget https://repo.anaconda.com/archive/Anaconda3-2020.11-Linux-x86_64.sh
-# RUN bash Anaconda3-2020.11-Linux-x86_64.sh -b
-
-# ENV PATH /root/anaconda3/bin:$PATH
-
-# RUN conda install -y -c tiledb tiledb
-# RUN conda install -y -c conda-forge tiledb-vector-search
-
-# WORKDIR /home/app
-# COPY requirements.txt run_algorithm.py ./
-# RUN pip3 install -r requirements.txt
-# ENTRYPOINT ["python", "-u", "run_algorithm.py"]
-
-# Pip approach
 FROM ann-benchmarks
 
-RUN pip install tiledb
-RUN pip install tiledb-vector-search
+RUN pip install tiledb tiledb-vector-search
 RUN python3 -c 'import tiledb.vector_search'

--- a/ann_benchmarks/algorithms/tiledb/module.py
+++ b/ann_benchmarks/algorithms/tiledb/module.py
@@ -61,11 +61,14 @@ class TileDBIVFFlat(BaseANN):
         X.tofile(f)
         f.close()
 
+        # TODO: Next time we run this, just use the numpy arrays directly for ingestion.
         if X.dtype == "uint8":
             source_type = "U8BIN"
         elif X.dtype == "float32":
             source_type = "F32BIN"
         maxtrain = min(50 * self._n_list, X.shape[0])
+        # TODO: Next time we run this, remove size, training_sample_size, partitions, and 
+        # input_vectors_per_work_item and use the defaults instead.
         self.index = ingest(
             index_type="IVF_FLAT",
             index_uri=array_uri,
@@ -77,6 +80,7 @@ class TileDBIVFFlat(BaseANN):
             input_vectors_per_work_item=100000000,
             mode=Mode.LOCAL
         )
+        # TODO: Next time we run this, remove dtype and memory_budget as these are the defaults.
         # memory_budget=-1 will load the data into main memory.
         self.index = IVFFlatIndex(uri=array_uri, dtype=X.dtype, memory_budget=-1)
 


### PR DESCRIPTION
### What
Updates the TileDB benchmarks.

### Results
![sift-128-euclidean_10_euclidean-batch](https://github.com/TileDB-Inc/ann-benchmarks/assets/1396242/4189bd67-9a62-480b-9ee0-d85ecce3a83d)

### How to run yourself
- Launch Amazon Linux x86 r6i.16xlarge EC2 instance.
- SSH in
- Install things:
```
sudo yum update -y

sudo yum install git -y

(maybe - check if you already have this) sudo yum install python3.11 -y
sudo yum install python3.11-pip -y
If you get mismatched Python versions
	sudo ln -sf /usr/bin/python3.11 /usr/bin/python
	sudo ln -sf /usr/bin/pip3.11 /usr/bin/pip
	sudo ln -sf /usr/bin/python3.11 /usr/bin/python3
	sudo ln -sf /usr/bin/pip3.11 /usr/bin/pip3

(maybe - check if you already have this) sudo yum install docker -y
sudo service docker start
sudo usermod -a -G docker ec2-user
(Log back out and log back in)
(Run this and make sure you see "docker") groups

mkdir repo
cd repo
git clone https://github.com/TileDB-Inc/ann-benchmarks.git
cd ann-benchmarks
git checkout npapa/tiledb
pip3 install -r requirements.txt
```
Then to run TileDB:
- `python install.py --algorithm tiledb`
- `pip3 install requests==2.28.1`
  - Fix for: https://github.com/docker/docker-py/issues/3113#issuecomment-1531621678
- `python run.py --dataset sift-128-euclidean --algorithm tiledb-ivf-flat --force --batch`
  - Note that only `--batch` mode works well currently, we need to investigate query mode. It will run but our performance is quite bad.
- `sudo chmod -R 777 results/sift-128-euclidean/10/tiledb-ivf-flat`
  - Fix for permissions error on in `results/sift-128-euclidean/10/tiledb-ivf-flat`
 - `python create_website.py`
 - Download `sift-128-euclidean_10_euclidean-batch.html` and `sift-128-euclidean_10_euclidean-batch.png`

Then to run all algorithms:
- `python install.py --algorithm tiledb`
- (note it will take a while, you can leave it overnight) `python run.py --dataset sift-128-euclidean --batch`