### PR TITLE
Add Vamana and Flat to the TileDB benchmarks

### DIFF
--- a/ann_benchmarks/algorithms/tiledb/config.yml
+++ b/ann_benchmarks/algorithms/tiledb/config.yml
@@ -7,6 +7,32 @@ float:
     module: ann_benchmarks.algorithms.tiledb
     name: tiledb-ivf-flat
     run_groups:
-      base:
-        args: [[512, 1024, 2048, 4096, 8192]]
+      IVFFLAT:
+        args: 
+          nlist: [[512, 1024, 2048, 4096, 8192]]
+        # n_probe:
         query_args: [[1, 5, 10, 50, 100, 200]]
+
+  - base_args: ['@metric']
+    constructor: TileDBFlat
+    disabled: false
+    docker_tag: ann-benchmarks-tiledb
+    module: ann_benchmarks.algorithms.tiledb
+    name: tiledb-flat
+    run_groups:
+      FLAT:
+        args:
+            placeholder: [0]
+
+  - base_args: ['@metric']
+    constructor: TileDBVamana
+    disabled: false
+    docker_tag: ann-benchmarks-tiledb
+    module: ann_benchmarks.algorithms.tiledb
+    name: tiledb-vamana
+    run_groups:
+      VAMANA:
+        args:
+            placeholder: [0]
+        # opt_l:
+        query_args: [[20, 40, 60, 80, 100, 120]]

--- a/ann_benchmarks/algorithms/tiledb/module.py
+++ b/ann_benchmarks/algorithms/tiledb/module.py
@@ -5,6 +5,8 @@ import tiledb
 
 from tiledb.vector_search.ingestion import ingest
 from tiledb.vector_search import IVFFlatIndex
+from tiledb.vector_search import FlatIndex
+from tiledb.vector_search import VamanaIndex
 from tiledb.cloud.dag import Mode
 import numpy as np
 import multiprocessing
@@ -12,11 +14,15 @@ import multiprocessing
 
 from ..base.module import BaseANN
 
-class TileDBIVFFlat(BaseANN):
-    def __init__(self, metric, n_list):
-        self._n_list = n_list
+MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
+
+class TileDB(BaseANN):
+    def __init__(self, metric, index_type, n_list = -1):
+        self._index_type = index_type
         self._metric = metric
-        self.MAX_UINT64 = np.iinfo(np.dtype("uint64")).max
+        self._n_list = n_list
+        self._n_probe = -1
+        self._opt_l = -1
 
     def query(self, v, n):
         if self._metric == 'angular':
@@ -27,10 +33,11 @@ class TileDBIVFFlat(BaseANN):
             np.array([v]).astype(numpy.float32), 
             k=n, 
             nthreads=multiprocessing.cpu_count(), 
-            nprobe=min(self._n_probe,self._n_list), 
+            nprobe=min(self._n_probe, self._n_list), 
+            opt_l=self._opt_l
         )[1][0]
         # Fix for 'OverflowError: Python int too large to convert to C long'.
-        ids[ids == self.MAX_UINT64] = 0
+        ids[ids == MAX_UINT64] = 0
         return ids 
 
     def batch_query(self, X, n):
@@ -44,7 +51,7 @@ class TileDBIVFFlat(BaseANN):
             nprobe=min(self._n_probe, self._n_list), 
         )[1]
         # Fix for 'OverflowError: Python int too large to convert to C long'.
-        self.res[self.res == self.MAX_UINT64] = 0
+        self.res[self.res == MAX_UINT64] = 0
 
     def get_batch_results(self):
         return self.res
@@ -55,18 +62,56 @@ class TileDBIVFFlat(BaseANN):
             os.remove(array_uri)
 
         self.index = ingest(
-            index_type="IVF_FLAT",
+            index_type=self._index_type,
             index_uri=array_uri,
             input_vectors=X,
             partitions=self._n_list,
         )
-        self.index = IVFFlatIndex(uri=array_uri)
-
-    def set_query_arguments(self, n_probe):
-        self._n_probe = n_probe
+        if self._index_type == "IVF_FLAT":
+            self.index = IVFFlatIndex(uri=array_uri)
+        elif self._index_type == "FLAT":
+            self.index = FlatIndex(uri=array_uri)
+        elif self._index_type == "VAMANA":
+            self.index = VamanaIndex(uri=array_uri)
+        else:
+            raise ValueError(f"Unsupported index {self._index_type}")
 
     def get_additional(self):
         return {}
 
+class TileDBIVFFlat(TileDB):
+    def __init__(self, metric, n_list):
+        super().__init__(
+            index_type="IVF_FLAT",
+            metric=metric,
+            n_list=n_list,
+        )
+    
+    def set_query_arguments(self, n_probe):
+        self._n_probe = n_probe
+
     def __str__(self):
         return 'TileDBIVFFlat(n_list=%d, n_probe=%d)' % (self._n_list, self._n_probe)
+
+class TileDBFlat(TileDB):
+    def __init__(self, metric, _):
+        super().__init__(
+            index_type="FLAT",
+            metric=metric
+        )
+    
+    def __str__(self):
+        return 'TileDBFlat()'
+
+class TileDBVamana(TileDB):
+    def __init__(self, metric, _):
+        super().__init__(
+            index_type="VAMANA",
+            metric=metric
+        )
+    
+    def set_query_arguments(self, opt_l):
+        self._opt_l = opt_l
+    
+    def __str__(self):
+        return 'TileDBVamana(opt_l=%d)' % (self._opt_l)


### PR DESCRIPTION
### What
Add Vamana and Flat to the TileDB benchmarks.

### Testing
* I am able to run Flat, though there is only a single datapoint, i.e. b/c we don't vary the query parameters we cannot move along the speed / recall curve. But still seems useful to check in so that we can make sure the recall never drops below 1.0.
* Vamana does not succeed - it fails with `No space left on device` - but this is with the current TileDB version which doesn't have all the Vamana fixes, so still seems fine to check it in and then we can iterate on it from there:
```
2024-06-11 15:09:19,648 - annb.2fa11d84e492 - ERROR -   File "/usr/local/lib/python3.10/dist-packages/tiledb/vector_search/ingestion.py", line 1645, in ingest_vamana

2024-06-11 15:09:19,648 - annb.2fa11d84e492 - ERROR -     index.write_index(ctx, index_group_uri, to_temporal_policy(index_timestamp))

2024-06-11 15:09:19,648 - annb.2fa11d84e492 - ERROR - tiledb.cc.TileDBError: TileDB internal: [OrderedWriter::dowork]  (IO Error: Cannot write to file '/tmp/array/adjacency_scores/__fragments/__1718115877119_1718115877119_24b445e43af5a9e0526e10446f732fde_21/a0.tdb'; POSIX write error:No space left on device)

2024-06-11 15:09:19,648 - annb.2fa11d84e492 - ERROR - Child process for container 2fa11d84e492 returned exit code 1 with message 
2024-06-11 15:09:19,648 - annb.2fa11d84e492 - INFO - Removing container
2024-06-11 15:09:19,697 - annb - INFO - Terminating 1 workers
```