### PR TITLE
Fix IVF Flat args

### DIFF
--- a/ann_benchmarks/algorithms/tiledb/config.yml
+++ b/ann_benchmarks/algorithms/tiledb/config.yml
@@ -8,8 +8,8 @@ float:
     name: tiledb-ivf-flat
     run_groups:
       IVFFLAT:
-        args: 
-          nlist: [[512, 1024, 2048, 4096, 8192]]
+        # n_list:
+        args: [[512, 1024, 2048, 4096, 8192]]
         # n_probe:
         query_args: [[1, 5, 10, 50, 100, 200]]
 


### PR DESCRIPTION
### What
I accidentally had incorrect `args` in a previous PR, fix here.

### Testing
Can run now:
```
ec2-user@ip-172-31-39-133 ann-benchmarks]$ python3 run.py --dataset sift-128-euclidean --algorithm tiledb-ivf-flat --force --batch
2024-06-12 11:39:29,158 - annb - INFO - running only tiledb-ivf-flat
2024-06-12 11:39:29,170 - annb - INFO - Order: [Definition(algorithm='tiledb-ivf-flat', constructor='TileDBIVFFlat', module='ann_benchmarks.algorithms.tiledb', docker_tag='ann-benchmarks-tiledb', arguments=['euclidean', 4096], query_argument_groups=[[1], [5], [10], [50], [100], [200]], disabled=False), Definition(algorithm='tiledb-ivf-flat', constructor='TileDBIVFFlat', module='ann_benchmarks.algorithms.tiledb', docker_tag='ann-benchmarks-tiledb', arguments=['euclidean', 1024], query_argument_groups=[[1], [5], [10], [50], [100], [200]], disabled=False), Definition(algorithm='tiledb-ivf-flat', constructor='TileDBIVFFlat', module='ann_benchmarks.algorithms.tiledb', docker_tag='ann-benchmarks-tiledb', arguments=['euclidean', 8192], query_argument_groups=[[1], [5], [10], [50], [100], [200]], disabled=False), Definition(algorithm='tiledb-ivf-flat', constructor='TileDBIVFFlat', module='ann_benchmarks.algorithms.tiledb', docker_tag='ann-benchmarks-tiledb', arguments=['euclidean', 2048], query_argument_groups=[[1], [5], [10], [50], [100], [200]], disabled=False), Definition(algorithm='tiledb-ivf-flat', constructor='TileDBIVFFlat', module='ann_benchmarks.algorithms.tiledb', docker_tag='ann-benchmarks-tiledb', arguments=['euclidean', 512], query_argument_groups=[[1], [5], [10], [50], [100], [200]], disabled=False)]
2024-06-12 11:39:29,370 - annb.7939b0b2a59d - INFO - Created container 7939b0b2a59d: CPU limit 0-63, mem limit 526680840960, timeout 7200, command ['--dataset', 'sift-128-euclidean', '--algorithm', 'tiledb-ivf-flat', '--module', 'ann_benchmarks.algorithms.tiledb', '--constructor', 'TileDBIVFFlat', '--runs', '5', '--count', '10', '--batch', '["euclidean", 4096]', '[1]', '[5]', '[10]', '[50]', '[100]', '[200]']
2024-06-12 11:39:29,577 - annb.7939b0b2a59d - INFO - ['euclidean', 4096]
2024-06-12 11:39:29,577 - annb.7939b0b2a59d - INFO - Trying to instantiate ann_benchmarks.algorithms.tiledb.TileDBIVFFlat(['euclidean', 4096])
2024-06-12 11:39:29,655 - annb.7939b0b2a59d - INFO - /usr/local/lib/python3.10/dist-packages/tiledb/cloud/config.py:96: UserWarning: You must first login before you can run commands. Please run tiledb.cloud.login.
2024-06-12 11:39:29,656 - annb.7939b0b2a59d - INFO -   warnings.warn(
2024-06-12 11:39:29,832 - annb.7939b0b2a59d - INFO - [TileDBIVFFlat@__init__] metric euclidean n_list 4096
2024-06-12 11:39:30,170 - annb.7939b0b2a59d - INFO - Got a train set of size (1000000 * 128)
2024-06-12 11:39:30,171 - annb.7939b0b2a59d - INFO - Got 10000 queries
2024-06-12 11:39:30,509 - annb.7939b0b2a59d - INFO - [TileDB@fit] _n_list 4096
2024-06-12 11:39:47,690 - annb.7939b0b2a59d - INFO - Built index in 17.181708812713623
2024-06-12 11:39:47,691 - annb.7939b0b2a59d - INFO - Index size:  1191704.0
2024-06-12 11:39:47,691 - annb.7939b0b2a59d - INFO - Running query argument group 1 of 6...
2024-06-12 11:39:47,691 - annb.7939b0b2a59d - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 1
2024-06-12 11:39:47,691 - annb.7939b0b2a59d - INFO - Run 1/5...
2024-06-12 11:39:48,395 - annb.7939b0b2a59d - INFO - Run 2/5...
2024-06-12 11:39:49,085 - annb.7939b0b2a59d - INFO - Run 3/5...
2024-06-12 11:39:49,744 - annb.7939b0b2a59d - INFO - Run 4/5...
2024-06-12 11:39:50,427 - annb.7939b0b2a59d - INFO - Run 5/5...
2024-06-12 11:39:52,403 - annb.7939b0b2a59d - INFO - Running query argument group 2 of 6...
2024-06-12 11:39:52,403 - annb.7939b0b2a59d - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 5
2024-06-12 11:39:52,404 - annb.7939b0b2a59d - INFO - Run 1/5...
2024-06-12 11:39:53,121 - annb.7939b0b2a59d - INFO - Run 2/5...
2024-06-12 11:39:53,817 - annb.7939b0b2a59d - INFO - Run 3/5...
2024-06-12 11:39:54,544 - annb.7939b0b2a59d - INFO - Run 4/5...
2024-06-12 11:39:55,236 - annb.7939b0b2a59d - INFO - Run 5/5...
2024-06-12 11:39:57,239 - annb.7939b0b2a59d - INFO - Running query argument group 3 of 6...
2024-06-12 11:39:57,239 - annb.7939b0b2a59d - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 10
2024-06-12 11:39:57,239 - annb.7939b0b2a59d - INFO - Run 1/5...
2024-06-12 11:39:57,992 - annb.7939b0b2a59d - INFO - Run 2/5...
2024-06-12 11:39:58,729 - annb.7939b0b2a59d - INFO - Run 3/5...
2024-06-12 11:39:59,488 - annb.7939b0b2a59d - INFO - Run 4/5...
2024-06-12 11:40:00,226 - annb.7939b0b2a59d - INFO - Run 5/5...
2024-06-12 11:40:02,317 - annb.7939b0b2a59d - INFO - Running query argument group 4 of 6...
2024-06-12 11:40:02,317 - annb.7939b0b2a59d - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 50
2024-06-12 11:40:02,317 - annb.7939b0b2a59d - INFO - Run 1/5...
2024-06-12 11:40:03,345 - annb.7939b0b2a59d - INFO - Run 2/5...
2024-06-12 11:40:04,415 - annb.7939b0b2a59d - INFO - Run 3/5...
2024-06-12 11:40:05,478 - annb.7939b0b2a59d - INFO - Run 4/5...
2024-06-12 11:40:06,515 - annb.7939b0b2a59d - INFO - Run 5/5...
2024-06-12 11:40:08,866 - annb.7939b0b2a59d - INFO - Running query argument group 5 of 6...
2024-06-12 11:40:08,866 - annb.7939b0b2a59d - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 100
2024-06-12 11:40:08,866 - annb.7939b0b2a59d - INFO - Run 1/5...
2024-06-12 11:40:10,259 - annb.7939b0b2a59d - INFO - Run 2/5...
2024-06-12 11:40:11,677 - annb.7939b0b2a59d - INFO - Run 3/5...
2024-06-12 11:40:13,063 - annb.7939b0b2a59d - INFO - Run 4/5...
2024-06-12 11:40:14,453 - annb.7939b0b2a59d - INFO - Run 5/5...
2024-06-12 11:40:17,172 - annb.7939b0b2a59d - INFO - Running query argument group 6 of 6...
2024-06-12 11:40:17,172 - annb.7939b0b2a59d - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 200
2024-06-12 11:40:17,172 - annb.7939b0b2a59d - INFO - Run 1/5...
2024-06-12 11:40:19,228 - annb.7939b0b2a59d - INFO - Run 2/5...
2024-06-12 11:40:21,317 - annb.7939b0b2a59d - INFO - Run 3/5...
2024-06-12 11:40:23,356 - annb.7939b0b2a59d - INFO - Run 4/5...
2024-06-12 11:40:25,435 - annb.7939b0b2a59d - INFO - Run 5/5...
2024-06-12 11:40:29,120 - annb.7939b0b2a59d - INFO - Child process for container 7939b0b2a59d returned exit code 0 with message 
2024-06-12 11:40:29,121 - annb.7939b0b2a59d - INFO - Removing container
2024-06-12 11:40:29,249 - annb.261263b50bcf - INFO - Created container 261263b50bcf: CPU limit 0-63, mem limit 526598114048, timeout 7200, command ['--dataset', 'sift-128-euclidean', '--algorithm', 'tiledb-ivf-flat', '--module', 'ann_benchmarks.algorithms.tiledb', '--constructor', 'TileDBIVFFlat', '--runs', '5', '--count', '10', '--batch', '["euclidean", 1024]', '[1]', '[5]', '[10]', '[50]', '[100]', '[200]']
2024-06-12 11:40:29,459 - annb.261263b50bcf - INFO - ['euclidean', 1024]
2024-06-12 11:40:29,459 - annb.261263b50bcf - INFO - Trying to instantiate ann_benchmarks.algorithms.tiledb.TileDBIVFFlat(['euclidean', 1024])
2024-06-12 11:40:29,537 - annb.261263b50bcf - INFO - /usr/local/lib/python3.10/dist-packages/tiledb/cloud/config.py:96: UserWarning: You must first login before you can run commands. Please run tiledb.cloud.login.
2024-06-12 11:40:29,537 - annb.261263b50bcf - INFO -   warnings.warn(
2024-06-12 11:40:29,691 - annb.261263b50bcf - INFO - [TileDBIVFFlat@__init__] metric euclidean n_list 1024
2024-06-12 11:40:30,033 - annb.261263b50bcf - INFO - Got a train set of size (1000000 * 128)
2024-06-12 11:40:30,034 - annb.261263b50bcf - INFO - Got 10000 queries
2024-06-12 11:40:30,374 - annb.261263b50bcf - INFO - [TileDB@fit] _n_list 1024
2024-06-12 11:40:39,621 - annb.261263b50bcf - INFO - Built index in 9.246887683868408
2024-06-12 11:40:39,622 - annb.261263b50bcf - INFO - Index size:  920996.0
2024-06-12 11:40:39,622 - annb.261263b50bcf - INFO - Running query argument group 1 of 6...
2024-06-12 11:40:39,622 - annb.261263b50bcf - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 1
2024-06-12 11:40:39,622 - annb.261263b50bcf - INFO - Run 1/5...
2024-06-12 11:40:40,333 - annb.261263b50bcf - INFO - Run 2/5...
2024-06-12 11:40:41,006 - annb.261263b50bcf - INFO - Run 3/5...
2024-06-12 11:40:41,693 - annb.261263b50bcf - INFO - Run 4/5...
2024-06-12 11:40:42,382 - annb.261263b50bcf - INFO - Run 5/5...
2024-06-12 11:40:44,405 - annb.261263b50bcf - INFO - Running query argument group 2 of 6...
2024-06-12 11:40:44,405 - annb.261263b50bcf - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 5
2024-06-12 11:40:44,405 - annb.261263b50bcf - INFO - Run 1/5...
2024-06-12 11:40:45,219 - annb.261263b50bcf - INFO - Run 2/5...
2024-06-12 11:40:46,009 - annb.261263b50bcf - INFO - Run 3/5...
2024-06-12 11:40:46,827 - annb.261263b50bcf - INFO - Run 4/5...
2024-06-12 11:40:47,615 - annb.261263b50bcf - INFO - Run 5/5...
2024-06-12 11:40:49,786 - annb.261263b50bcf - INFO - Running query argument group 3 of 6...
2024-06-12 11:40:49,787 - annb.261263b50bcf - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 10
2024-06-12 11:40:49,787 - annb.261263b50bcf - INFO - Run 1/5...
2024-06-12 11:40:50,712 - annb.261263b50bcf - INFO - Run 2/5...
2024-06-12 11:40:51,677 - annb.261263b50bcf - INFO - Run 3/5...
2024-06-12 11:40:52,603 - annb.261263b50bcf - INFO - Run 4/5...
2024-06-12 11:40:53,566 - annb.261263b50bcf - INFO - Run 5/5...
2024-06-12 11:40:55,859 - annb.261263b50bcf - INFO - Running query argument group 4 of 6...
2024-06-12 11:40:55,859 - annb.261263b50bcf - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 50
2024-06-12 11:40:55,860 - annb.261263b50bcf - INFO - Run 1/5...
2024-06-12 11:40:57,879 - annb.261263b50bcf - INFO - Run 2/5...
2024-06-12 11:40:59,881 - annb.261263b50bcf - INFO - Run 3/5...
2024-06-12 11:41:01,917 - annb.261263b50bcf - INFO - Run 4/5...
2024-06-12 11:41:03,916 - annb.261263b50bcf - INFO - Run 5/5...
2024-06-12 11:41:07,316 - annb.261263b50bcf - INFO - Running query argument group 5 of 6...
2024-06-12 11:41:07,316 - annb.261263b50bcf - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 100
2024-06-12 11:41:07,316 - annb.261263b50bcf - INFO - Run 1/5...
2024-06-12 11:41:10,633 - annb.261263b50bcf - INFO - Run 2/5...
2024-06-12 11:41:13,929 - annb.261263b50bcf - INFO - Run 3/5...
2024-06-12 11:41:17,251 - annb.261263b50bcf - INFO - Run 4/5...
2024-06-12 11:41:20,539 - annb.261263b50bcf - INFO - Run 5/5...
2024-06-12 11:41:25,203 - annb.261263b50bcf - INFO - Running query argument group 6 of 6...
2024-06-12 11:41:25,204 - annb.261263b50bcf - INFO - [TileDBIVFFlat@set_query_arguments] n_probe 200
...
```