### PR TITLE
Add TileDB IVF PQ

### DIFF
--- a/ann_benchmarks/algorithms/tiledb/config.yml
+++ b/ann_benchmarks/algorithms/tiledb/config.yml
@@ -36,3 +36,16 @@ float:
             placeholder: [0]
         # opt_l:
         query_args: [[20, 40, 60, 80, 100, 120]]
+  
+  - base_args: ['@metric']
+    constructor: TileDBIVFPQ
+    disabled: false
+    docker_tag: ann-benchmarks-tiledb
+    module: ann_benchmarks.algorithms.tiledb
+    name: tiledb-ivf-pq
+    run_groups:
+      IVFPQ:
+        args:
+            placeholder: [0]
+        # n_probe:
+        query_args: [[20, 40, 60, 80, 100, 120]]


### PR DESCRIPTION
### What
Adds IVF PQ. There is still more we can do to tune `num_subspaces=dimensions/2`, but the goal is to get something in quickly so I can add it to the benchmark runner script.

### Testing
![sift-128-euclidean_10_euclidean-batch_ 2](https://github.com/TileDB-Inc/ann-benchmarks/assets/1396242/6b12fc17-a3f0-4caa-91a9-8543957fd57b)
